### PR TITLE
Team 9 day night cycle pause

### DIFF
--- a/source/core/src/main/com/deco2800/game/services/DayNightCycleService.java
+++ b/source/core/src/main/com/deco2800/game/services/DayNightCycleService.java
@@ -26,12 +26,16 @@ public class DayNightCycleService {
     private int currentDayNumber;
     private long currentDayMillis;
 
+    private long timePaused;
+
+    private long totalDurationPaused;
+
     private boolean isPaused;
 
     private boolean isStarted;
 
-    private DayNightCycleConfig config;
-    private GameTime timer;
+    private final DayNightCycleConfig config;
+    private final GameTime timer;
 
     private EventHandler events;
 
@@ -41,6 +45,7 @@ public class DayNightCycleService {
         this.currentCycleStatus = DayNightCycleStatus.NONE;
         this.isStarted = false;
         this.isPaused = false;
+        this.totalDurationPaused = 0;
         this.currentDayNumber = 0;
         this.currentDayMillis = timer.getTime();
         this.config = config;
@@ -135,20 +140,33 @@ public class DayNightCycleService {
      */
     public void pause() {
         this.isPaused = true;
+        this.timePaused = this.currentDayMillis;
+        System.out.println("");
+        System.out.println("");
+        System.out.println("");
+        System.out.println("Time Paused: " + this.timePaused);
+        System.out.println("");
+        System.out.println("");
+        System.out.println("");
     }
 
     /**
      * Main loop for the service that updates the game status.
      */
     public void run() throws InterruptedException {
+        long durationPaused = 0;
 
         while (!this.ended) {
 
             if (!this.isPaused) {
+                if (durationPaused != 0) {
+                    this.totalDurationPaused += durationPaused;
+                    durationPaused = 0;
+                }
 
                 // Definitely a better way to do this but this works for now
                 this.currentDayMillis = this.timer.getTime() - (this.currentDayNumber * (config.nightLength +
-                        config.duskLength + config.dayLength + config.dawnLength));
+                        config.duskLength + config.dayLength + config.dawnLength)) - this.totalDurationPaused;
 
                 if (this.currentDayMillis >= config.dawnLength && this.currentCycleStatus == DayNightCycleStatus.DAWN) {
                     this.setPartOfDayTo(DayNightCycleStatus.DAY);
@@ -176,6 +194,9 @@ public class DayNightCycleService {
 
                     this.currentDayMillis = 0;
                 }
+            } else {
+                // Keep track of how long the game has been paused this time.
+                durationPaused = this.timer.getTimeSince(this.timePaused);
             }
         }
     }

--- a/source/core/src/main/com/deco2800/game/services/DayNightCycleService.java
+++ b/source/core/src/main/com/deco2800/game/services/DayNightCycleService.java
@@ -141,13 +141,6 @@ public class DayNightCycleService {
     public void pause() {
         this.isPaused = true;
         this.timePaused = this.currentDayMillis;
-        System.out.println("");
-        System.out.println("");
-        System.out.println("");
-        System.out.println("Time Paused: " + this.timePaused);
-        System.out.println("");
-        System.out.println("");
-        System.out.println("");
     }
 
     /**

--- a/source/core/src/main/com/deco2800/game/services/DayNightCycleService.java
+++ b/source/core/src/main/com/deco2800/game/services/DayNightCycleService.java
@@ -98,6 +98,15 @@ public class DayNightCycleService {
     }
 
     /**
+     * Returns the game timer
+     *
+     * @return GameTime
+     */
+    public GameTime getTimer() {
+        return this.timer;
+    }
+
+    /**
      * Starts the day night cycle for the game.
      *
      * @return a future that can be used to join.

--- a/source/core/src/test/com/deco2800/game/services/DayNightCycleServiceTest.java
+++ b/source/core/src/test/com/deco2800/game/services/DayNightCycleServiceTest.java
@@ -10,6 +10,7 @@ import org.mockito.Mockito;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -50,7 +51,8 @@ public class DayNightCycleServiceTest {
         this.dayNightCycleService.start().join();
     }
 
-    @Test void shouldCompleteFullCyclePassingThroughAllPartsOfDay() {
+    @Test
+    public void shouldCompleteFullCyclePassingThroughAllPartsOfDay() {
         List<DayNightCycleStatus> partsOfDay = new ArrayList<>();
 
         this.dayNightCycleService.getEvents().addListener(DayNightCycleService.EVENT_PART_OF_DAY_PASSED,
@@ -94,7 +96,8 @@ public class DayNightCycleServiceTest {
         assertTrue(this.dayNightCycleService.hasEnded());
     }
 
-    @Test void shouldGoThroughAllNumberOfDays() {
+    @Test
+    public void shouldGoThroughAllNumberOfDays() {
         this.config.maxDays = 3;
         AtomicInteger days = new AtomicInteger(0);
         this.dayNightCycleService.getEvents().addListener(DayNightCycleService.EVENT_DAY_PASSED,
@@ -107,5 +110,24 @@ public class DayNightCycleServiceTest {
         assertEquals(this.config.maxDays, days.get());
     }
 
+    @Test
+    public void shouldStopDayTimeWhenPaused() {
+        this.dayNightCycleService.start();
+        this.dayNightCycleService.pause();
 
+        assertTrue(this.dayNightCycleService.getCurrentDayMillis() < 1000);
+    }
+
+    @Test
+    public void shouldResumeDayTimeWhenResumed() {
+        CompletableFuture<Object> job = this.dayNightCycleService.start();
+        this.dayNightCycleService.pause();
+
+        assertTrue(this.dayNightCycleService.getCurrentDayMillis() < 1000);
+
+        this.dayNightCycleService.start();
+        job.join();
+
+        assertTrue(this.dayNightCycleService.getCurrentDayMillis() > 1000);
+    }
 }

--- a/source/core/src/test/com/deco2800/game/services/DayNightCycleServiceTest.java
+++ b/source/core/src/test/com/deco2800/game/services/DayNightCycleServiceTest.java
@@ -115,7 +115,14 @@ public class DayNightCycleServiceTest {
         this.dayNightCycleService.start();
         this.dayNightCycleService.pause();
 
-        assertTrue(this.dayNightCycleService.getCurrentDayMillis() < 1000);
+        try {
+            Thread.sleep(300);
+        } catch(InterruptedException e) {
+            System.err.println(e.getMessage());
+        }
+
+        assertTrue(this.dayNightCycleService.getTimer().getTime() > 300);
+        assertTrue(this.dayNightCycleService.getCurrentDayMillis() < 300);
     }
 
     @Test


### PR DESCRIPTION
Updated run of DayNightCycleService method to support pausing and resuming the day night cycle.
Wrote tests in DayNightCycleServiceTest to ensure that the day night cycle is correctly pausing and resuming the game timer.