### PR TITLE
Team9 day night filter

### DIFF
--- a/source/core/assets/configs/DayNight.json
+++ b/source/core/assets/configs/DayNight.json
@@ -1,7 +1,7 @@
 {
-  "dawnLength": 1000,
-  "dayLength": 10000,
-  "duskLength": 1000,
-  "nightLength": 6000,
+  "dawnLength": 15000,
+  "dayLength": 30000,
+  "duskLength": 30000,
+  "nightLength": 15000,
   "maxDays": 4
 }

--- a/source/core/assets/shaders/base.vert
+++ b/source/core/assets/shaders/base.vert
@@ -11,8 +11,4 @@ void main() {
     vColor = a_color;
     vTexCoord = a_texCoord0;
     gl_Position = u_projTrans * a_position;
-
-    //gl_Position = ftransform();
-    //gl_FrontColor = gl_Color;
-    //gl_TexCoord[0] = gl_MultiTexCoord0;
 }

--- a/source/core/assets/shaders/base.vert
+++ b/source/core/assets/shaders/base.vert
@@ -1,0 +1,18 @@
+attribute vec4 a_position;
+attribute vec4 a_color;
+attribute vec2 a_texCoord0;
+
+uniform mat4 u_projTrans;
+
+varying vec4 vColor;
+varying vec2 vTexCoord;
+
+void main() {
+    vColor = a_color;
+    vTexCoord = a_texCoord0;
+    gl_Position = u_projTrans * a_position;
+
+    //gl_Position = ftransform();
+    //gl_FrontColor = gl_Color;
+    //gl_TexCoord[0] = gl_MultiTexCoord0;
+}

--- a/source/core/assets/shaders/light.frag
+++ b/source/core/assets/shaders/light.frag
@@ -1,0 +1,30 @@
+#ifdef GL_ES
+#define LOWP lowp
+precision mediump float;
+#else
+#define LOWP
+#endif
+
+varying LOWP vec4 vColor;
+varying vec2 vTexCoord;
+
+//texture samplers
+uniform sampler2D u_texture; //diffuse map
+uniform sampler2D u_lightmap;   //light map
+
+//additional parameters for the shader
+uniform vec2 resolution; //resolution of screen
+uniform LOWP vec4 ambientColor; //ambient RGB, alpha channel is intensity
+
+void main() {
+    vec4 diffuseColor = texture2D(u_texture, vTexCoord);
+    vec2 lighCoord = (gl_FragCoord.xy / resolution.xy);
+    vec4 light = texture2D(u_lightmap, lighCoord);
+
+    vec3 ambient = ambientColor.rgb * ambientColor.a;
+    vec3 intensity = ambient + light.rgb;
+    vec3 finalColor = diffuseColor.rgb * intensity;
+
+    gl_FragColor = vColor * vec4(finalColor, diffuseColor.a);
+
+}

--- a/source/core/src/main/com/deco2800/game/AtlantisSinks.java
+++ b/source/core/src/main/com/deco2800/game/AtlantisSinks.java
@@ -5,12 +5,7 @@ import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Screen;
 import com.deco2800.game.files.UserSettings;
 import com.deco2800.game.memento.CareTaker;
-import com.deco2800.game.screens.MainGameScreen;
-import com.deco2800.game.screens.MainMenuScreen;
-import com.deco2800.game.screens.SettingsScreen;
-import com.deco2800.game.screens.ShopArtefactScreen;
-import com.deco2800.game.screens.ShopBuildScreen;
-import com.deco2800.game.screens.ShopScreen;
+import com.deco2800.game.screens.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -25,6 +20,8 @@ import static com.badlogic.gdx.Gdx.app;
  */
 public class AtlantisSinks extends Game {
   private static final Logger logger = LoggerFactory.getLogger(AtlantisSinks.class);
+
+  public static boolean gameRunning = false;
 
   @Override
   public void create() {
@@ -86,6 +83,8 @@ public class AtlantisSinks extends Game {
    * @return new screen
    */
   private Screen newScreen(ScreenType screenType, CareTaker playerStatus) {
+    gameRunning = screenType == ScreenType.MAIN_GAME;
+
     switch (screenType) {
       case MAIN_MENU:
         return new MainMenuScreen(this);

--- a/source/core/src/main/com/deco2800/game/rendering/DayNightCycleComponent.java
+++ b/source/core/src/main/com/deco2800/game/rendering/DayNightCycleComponent.java
@@ -1,0 +1,87 @@
+package com.deco2800.game.rendering;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.graphics.Pixmap;
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.badlogic.gdx.graphics.g2d.TextureRegion;
+import com.badlogic.gdx.graphics.glutils.ShaderProgram;
+import com.badlogic.gdx.math.Vector3;
+import com.deco2800.game.services.DayNightCycleService;
+import com.deco2800.game.services.DayNightCycleStatus;
+import com.deco2800.game.services.ServiceLocator;
+
+/**
+ * This class is responsible for shading the game screen when invoked in RendererService
+ */
+public class DayNightCycleComponent {
+
+    private final ShaderProgram dayNightCycleShader;
+    public static final TextureRegion BLACK_IMAGE = new TextureRegion();
+
+    private static final float NIGHT_INTENSITY = 0.75f;
+    private static final float DUSK_INTENSITY = 0.95f;
+    private static final float DAWN_INTENSITY = 0.095f;
+    private static final float DAY_INTENSITY = 0.2f;
+
+    private static final  Vector3 bright = new Vector3(6.3f, 6.3f, 6.7f);
+
+    private static final Vector3 dark = new Vector3(0.3f, 0.3f, 0.7f);
+
+    private Vector3 ambientColour;
+
+    private float intensity;
+
+    public DayNightCycleComponent() {
+
+        Pixmap map = new Pixmap(128, 128, Pixmap.Format.RGBA8888);;
+        map.setColor(Color.BLACK);
+        map.fillRectangle(0, 0, map.getWidth(), map.getHeight());
+        BLACK_IMAGE.setTexture(new Texture(map));
+
+        this.ambientColour = bright;
+        this.intensity = DAY_INTENSITY;
+
+        ShaderProgram.pedantic = false;
+        var vertexShader = Gdx.files.internal("shaders/base.vert");
+        var lightShader=  Gdx.files.internal("shaders/light.frag");
+        this.dayNightCycleShader = new ShaderProgram(vertexShader, lightShader);
+
+        /* Subscribe to part of day changes */
+        ServiceLocator.getDayNightCycleService().getEvents().addListener(DayNightCycleService.EVENT_PART_OF_DAY_PASSED,
+                this::onPartOfDayChange);
+    }
+
+    public void render(SpriteBatch batch) {
+        dayNightCycleShader.bind();
+        {
+            dayNightCycleShader.setUniformi("u_lightmap", 1);
+            dayNightCycleShader.setUniformf("ambientColor", ambientColour.x, ambientColour.y, ambientColour.z, intensity);
+            dayNightCycleShader.setUniformf("resolution", Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+            batch.setShader(dayNightCycleShader);
+            Texture tex = BLACK_IMAGE.getTexture();
+            tex.bind(0);
+        }
+    }
+
+    public void onPartOfDayChange(DayNightCycleStatus partOfDay) {
+        this.intensity = switch (partOfDay) {
+            case DAWN -> DAWN_INTENSITY;
+            case DAY -> DAY_INTENSITY;
+            case DUSK -> DUSK_INTENSITY;
+            case NIGHT -> NIGHT_INTENSITY;
+            default -> 0.5f;
+        };
+
+        this.ambientColour = switch (partOfDay) {
+            case DAWN,DAY -> bright;
+            case DUSK, NIGHT -> dark;
+            default -> bright;
+        };
+    }
+
+    public ShaderProgram getDayNightCycleShader() {
+        return dayNightCycleShader;
+    }
+}

--- a/source/core/src/main/com/deco2800/game/rendering/RenderService.java
+++ b/source/core/src/main/com/deco2800/game/rendering/RenderService.java
@@ -4,6 +4,7 @@ import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.Disposable;
+import com.deco2800.game.AtlantisSinks;
 import com.deco2800.game.utils.SortedIntMap;
 
 /**
@@ -15,6 +16,8 @@ public class RenderService implements Disposable {
   private static final int INITIAL_CAPACITY = 4;
   private Stage stage;
   private DebugRenderer debugRenderer;
+
+  private DayNightCycleComponent dayNightCycleComponent;
 
   /**
    * Map from layer to list of renderables, allows us to render each layer in the correct order
@@ -60,6 +63,11 @@ public class RenderService implements Disposable {
 
       for (Renderable renderable : layer) {
         renderable.render(batch);
+        if (dayNightCycleComponent != null) {
+          if (AtlantisSinks.gameRunning) {
+            dayNightCycleComponent.render(batch);
+          }
+        }
       }
     }
   }
@@ -68,6 +76,9 @@ public class RenderService implements Disposable {
     this.stage = stage;
   }
 
+  public void setDayNightCycleComponent(DayNightCycleComponent dayNightCycleComponent) {
+    this.dayNightCycleComponent = dayNightCycleComponent;
+  }
   public Stage getStage() {
     return stage;
   }

--- a/source/core/src/main/com/deco2800/game/screens/MainGameScreen.java
+++ b/source/core/src/main/com/deco2800/game/screens/MainGameScreen.java
@@ -6,28 +6,32 @@ import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.deco2800.game.AtlantisSinks;
 import com.deco2800.game.areas.ForestGameArea;
 import com.deco2800.game.areas.terrain.TerrainFactory;
+import com.deco2800.game.components.gamearea.PerformanceDisplay;
 import com.deco2800.game.components.maingame.MainGameActions;
+import com.deco2800.game.components.maingame.MainGameExitDisplay;
 import com.deco2800.game.components.maingame.MainGameInterface;
 import com.deco2800.game.entities.Entity;
 import com.deco2800.game.entities.EntityService;
 import com.deco2800.game.entities.factories.RenderFactory;
+import com.deco2800.game.files.FileLoader;
 import com.deco2800.game.input.InputComponent;
 import com.deco2800.game.input.InputDecorator;
 import com.deco2800.game.input.InputService;
+import com.deco2800.game.memento.CareTaker;
 import com.deco2800.game.physics.PhysicsEngine;
 import com.deco2800.game.physics.PhysicsService;
+import com.deco2800.game.rendering.DayNightCycleComponent;
 import com.deco2800.game.rendering.RenderService;
 import com.deco2800.game.rendering.Renderer;
+import com.deco2800.game.services.DayNightCycleService;
 import com.deco2800.game.services.GameTime;
 import com.deco2800.game.services.ResourceService;
 import com.deco2800.game.services.ServiceLocator;
+import com.deco2800.game.services.configs.DayNightCycleConfig;
 import com.deco2800.game.ui.terminal.Terminal;
 import com.deco2800.game.ui.terminal.TerminalDisplay;
-import com.deco2800.game.components.maingame.MainGameExitDisplay;
-import com.deco2800.game.components.gamearea.PerformanceDisplay;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import com.deco2800.game.memento.CareTaker;
 
 /**
  * The game screen containing the main game.
@@ -72,6 +76,10 @@ public class MainGameScreen extends ScreenAdapter {
     logger.debug("Initialising main game screen services");
     ServiceLocator.registerTimeSource(new GameTime());
 
+    var dayNightCycleService = new DayNightCycleService(ServiceLocator.getTimeSource(),
+            FileLoader.readClass(DayNightCycleConfig.class, "configs/DayNight.json"));
+    ServiceLocator.registerDayNightCycleService(dayNightCycleService);
+
     PhysicsService physicsService = new PhysicsService();
     ServiceLocator.registerPhysicsService(physicsService);
     physicsEngine = physicsService.getPhysics();
@@ -81,6 +89,7 @@ public class MainGameScreen extends ScreenAdapter {
 
     ServiceLocator.registerEntityService(new EntityService());
     ServiceLocator.registerRenderService(new RenderService());
+    ServiceLocator.getRenderService().setDayNightCycleComponent(new DayNightCycleComponent());
 
     renderer = RenderFactory.createRenderer();
     renderer.getCamera().getEntity().setPosition(CAMERA_POSITION);
@@ -93,6 +102,7 @@ public class MainGameScreen extends ScreenAdapter {
     this.forestGameArea = new ForestGameArea(terrainFactory, playerStatus);
     forestGameArea.create();
     createUI();
+    ServiceLocator.getDayNightCycleService().start();
   }
 
   @Override

--- a/source/core/src/main/com/deco2800/game/services/ServiceLocator.java
+++ b/source/core/src/main/com/deco2800/game/services/ServiceLocator.java
@@ -24,6 +24,8 @@ public class ServiceLocator {
   private static InputService inputService;
   private static ResourceService resourceService;
 
+  private static DayNightCycleService dayNightCycleService;
+
 
   public static EntityService getEntityService() {
     return entityService;
@@ -47,6 +49,10 @@ public class ServiceLocator {
 
   public static ResourceService getResourceService() {
     return resourceService;
+  }
+
+  public static DayNightCycleService getDayNightCycleService () {
+    return dayNightCycleService;
   }
 
   public static void registerEntityService(EntityService service) {
@@ -79,6 +85,11 @@ public class ServiceLocator {
     resourceService = source;
   }
 
+  public static void registerDayNightCycleService(DayNightCycleService source) {
+    logger.debug("Registering day night cycle service {}", source);
+    dayNightCycleService = source;
+  }
+
   public static void clear() {
     entityService = null;
     renderService = null;
@@ -86,6 +97,7 @@ public class ServiceLocator {
     timeSource = null;
     inputService = null;
     resourceService = null;
+    dayNightCycleService = null;
   }
 
   private ServiceLocator() {


### PR DESCRIPTION
This pull request introduces a changing night and day cycle. A component has been added that responds to events from the day night cycle service to shade the game area accordingly. Length of parts of the day have been made shorter for ease of testing. Values in the component can be adjusted to control the intensity of the shading. 

This is still in beta and will likely require more work in parts of later Sprint. Changes were also made to be able to know if the game screen is active. The shading only affects the gamescreen and not the menu or shop screens .