### PR TITLE
Do not use shader on UI elements #128

### DIFF
--- a/source/core/src/main/com/deco2800/game/rendering/Renderer.java
+++ b/source/core/src/main/com/deco2800/game/rendering/Renderer.java
@@ -101,6 +101,7 @@ public class Renderer implements Disposable {
     batch.end();
     debugRenderer.render(projMatrix);
 
+    batch.setShader(null);
     stage.act();
     stage.draw();
   }


### PR DESCRIPTION
Fixes a bug to allow UI elements to be exempt from the shader. Hence UI elements maintain their original look and colours throughout.