### PR TITLE
Team9 day night cycle service fix threading bug

### DIFF
--- a/source/core/src/main/com/deco2800/game/services/DayNightCycleService.java
+++ b/source/core/src/main/com/deco2800/game/services/DayNightCycleService.java
@@ -1,5 +1,6 @@
 package com.deco2800.game.services;
 
+import com.badlogic.gdx.Gdx;
 import com.deco2800.game.concurrency.JobSystem;
 import com.deco2800.game.events.EventHandler;
 import com.deco2800.game.services.configs.DayNightCycleConfig;
@@ -228,14 +229,20 @@ public class DayNightCycleService {
                     if (this.currentDayNumber == config.maxDays - 1) {
                         // End the game
                         this.stop();
-                        events.trigger(EVENT_DAY_PASSED, this.currentDayNumber);
+
+                        Gdx.app.postRunnable(() -> {
+                            events.trigger(EVENT_DAY_PASSED, this.currentDayNumber);
+                        });
                         return;
                     }
 
                     this.setPartOfDayTo(DayNightCycleStatus.DAWN);
                     // Notify entities that it is now DAY
                     this.currentDayNumber++;
-                    events.trigger(EVENT_DAY_PASSED, this.currentDayNumber);
+                    Gdx.app.postRunnable(() -> {
+                        events.trigger(EVENT_DAY_PASSED, this.currentDayNumber);
+                    });
+
 
                     this.currentDayMillis = 0;
                 }
@@ -258,7 +265,9 @@ public class DayNightCycleService {
         this.lastCycleStatus = currentCycleStatus;
         this.currentCycleStatus = nextPartOfDay;
         // helps with testing
-        this.events.trigger(EVENT_PART_OF_DAY_PASSED, nextPartOfDay);
+        Gdx.app.postRunnable(() -> {
+            this.events.trigger(EVENT_PART_OF_DAY_PASSED, nextPartOfDay);
+        });
     }
 
     /**

--- a/source/core/src/test/com/deco2800/game/services/DayNightCycleServiceTest.java
+++ b/source/core/src/test/com/deco2800/game/services/DayNightCycleServiceTest.java
@@ -97,7 +97,7 @@ public class DayNightCycleServiceTest {
     }
 
     @Test
-    public void shouldGoThroughAllNumberOfDays() {
+    public void shouldGoThroughAllNumberOfDays() throws InterruptedException {
         this.config.maxDays = 3;
         AtomicInteger days = new AtomicInteger(0);
         this.dayNightCycleService.getEvents().addListener(DayNightCycleService.EVENT_DAY_PASSED,
@@ -105,6 +105,7 @@ public class DayNightCycleServiceTest {
             days.incrementAndGet();
         });
         dayNightCycleService.start().join();
+        Thread.sleep(300); // fixes flakyness
 
         assertEquals(3, dayNightCycleService.getCurrentDayNumber());
         assertEquals(this.config.maxDays, days.get());


### PR DESCRIPTION
Fixes a bug that causes game to crash because threaded code attempts access game features only avaialble in game loop. The fix allows threads to be posted to main game loop for the day night cycle service.