### PR TITLE
bug fixes and fixing tests #128

### DIFF
--- a/source/core/src/main/com/deco2800/game/services/DayNightCycleService.java
+++ b/source/core/src/main/com/deco2800/game/services/DayNightCycleService.java
@@ -40,11 +40,13 @@ public class DayNightCycleService {
     private final DayNightCycleConfig config;
     private final GameTime timer;
 
-    private long timePerHalveOfDay;
+    private long timeSinceLastPartOfDay;
 
-    private int timePerHalveIteration;
+    private long timePerHalveOfPartOfDay;
 
-    private long currentPartOfDayLength;
+    private int partOfDayHalveIteration;
+
+    private int lastPartOfDayHalveIteration;
 
     private EventHandler events;
 
@@ -214,6 +216,19 @@ public class DayNightCycleService {
 
         while (!this.ended) {
 
+            // Move clock for parts of day with more than one half
+            if (this.currentCycleStatus == DayNightCycleStatus.DAY ||
+                    this.currentCycleStatus == DayNightCycleStatus.NIGHT) {
+                long elapsed = System.currentTimeMillis() - timeSinceLastPartOfDay;
+                if ((elapsed >= timePerHalveOfPartOfDay * partOfDayHalveIteration || partOfDayHalveIteration == 1) &&
+                        partOfDayHalveIteration != lastPartOfDayHalveIteration) {
+                    Gdx.app.postRunnable(() -> {
+                        events.trigger(EVENT_INTERMITTENT_PART_OF_DAY_CLOCK);
+                    });
+                    partOfDayHalveIteration++;
+                }
+            }
+
             if (!this.isPaused) {
                 if (durationPaused != 0) {
                     this.totalDurationPaused += durationPaused;
@@ -257,15 +272,6 @@ public class DayNightCycleService {
                     this.currentDayMillis = 0;
                 }
 
-                // Move clock for parts of day with more halves
-                if (this.currentCycleStatus == DayNightCycleStatus.DAY || this.currentCycleStatus == DayNightCycleStatus.NIGHT) {
-                    if (currentPartOfDayLength % (timePerHalveOfDay*timePerHalveIteration) == 0) {
-                        Gdx.app.postRunnable(() -> {
-                            events.trigger(EVENT_INTERMITTENT_PART_OF_DAY_CLOCK);
-                        });
-                        timePerHalveIteration++;
-                    }
-                }
             } else {
                 // Keep track of how long the game has been paused this time.
                 durationPaused = this.timer.getTimeSince(this.timePaused);
@@ -288,16 +294,16 @@ public class DayNightCycleService {
         Gdx.app.postRunnable(() -> {
             this.events.trigger(EVENT_PART_OF_DAY_PASSED, nextPartOfDay);
         });
-        
+        this.timeSinceLastPartOfDay = System.currentTimeMillis();
         if (nextPartOfDay == DayNightCycleStatus.NIGHT) {
-            this.timePerHalveOfDay = config.nightLength / 2;
-            this.timePerHalveIteration = 1;
-            this.currentPartOfDayLength = config.nightLength;
+            this.timePerHalveOfPartOfDay = config.nightLength / 2;
+            lastPartOfDayHalveIteration = 2;
+            this.partOfDayHalveIteration = 1;
         }
         if (nextPartOfDay == DayNightCycleStatus.DAY) {
-            this.timePerHalveOfDay = config.dayLength / 4;
-            this.timePerHalveIteration = 1;
-            this.currentPartOfDayLength = config.dayLength;
+            this.timePerHalveOfPartOfDay = config.dayLength / 4;
+            lastPartOfDayHalveIteration = 4;
+            this.partOfDayHalveIteration = 1;;
         }
     }
 


### PR DESCRIPTION
This PR fixes a bug where the clock movement events were sent without their respective delay for each wedge. Tests have been added to make sure these delays are there. 

In its current state both EVENT_PART_OF_DAY_PASSED and EVENT_INTERMITTENT_PART_OF_DAY_CLOCK will return a total of 8 calls. Each call moves the hand to the wedge.

Please note wrong commit hash was used. CORRECT hash  #101
