### PR TITLE
Team9 day night cycle improvements

### DIFF
--- a/source/core/src/main/com/deco2800/game/rendering/DayNightCycleComponent.java
+++ b/source/core/src/main/com/deco2800/game/rendering/DayNightCycleComponent.java
@@ -25,7 +25,7 @@ public class DayNightCycleComponent {
     private final ShaderProgram dayNightCycleShader;
     public static final TextureRegion BLACK_IMAGE = new TextureRegion();
 
-    public static final float NIGHT_INTENSITY = 0.055f;
+    public static final float NIGHT_INTENSITY = 0.015f;
     public static final float DUSK_INTENSITY = 0.075f;
     public static final float DAWN_INTENSITY = 0.095f;
     public static final float DAY_INTENSITY = 0.15f;
@@ -85,7 +85,11 @@ public class DayNightCycleComponent {
      * @param batch the sprite batch to apply the filter to
      */
     public void render(SpriteBatch batch) {
-        this.fade();
+
+        if (!ServiceLocator.getDayNightCycleService().hasEnded()) {
+            this.fade();
+        }
+
         dayNightCycleShader.bind();
         {
             dayNightCycleShader.setUniformi("u_lightmap", 1);
@@ -147,17 +151,17 @@ public class DayNightCycleComponent {
     private void fade() {
         if (currentPartOfDay != null) {
             if (shouldFade()) {
-                this.intensity = switch (currentPartOfDay) {
-                    case DAWN, NIGHT -> intensity + getCycleIntensityStep(currentPartOfDay);
-                    case DAY, DUSK -> intensity - getCycleIntensityStep(currentPartOfDay);
-                    default -> intensity;
-                };
+                    this.intensity = switch (currentPartOfDay) {
+                        case DAWN, NIGHT -> intensity + getCycleIntensityStep(currentPartOfDay);
+                        case DAY, DUSK -> intensity - getCycleIntensityStep(currentPartOfDay);
+                        default -> intensity;
+                    };
 
-                this.ambientColour = bright;
+                    this.ambientColour = bright;
 
-                this.lastIntensityFade = System.currentTimeMillis();
-            }
-        }
+                    this.lastIntensityFade = System.currentTimeMillis();
+                }
+                }
     }
 
     /**

--- a/source/core/src/main/com/deco2800/game/rendering/DayNightCycleComponent.java
+++ b/source/core/src/main/com/deco2800/game/rendering/DayNightCycleComponent.java
@@ -25,16 +25,20 @@ public class DayNightCycleComponent {
     private final ShaderProgram dayNightCycleShader;
     public static final TextureRegion BLACK_IMAGE = new TextureRegion();
 
-    public static final float NIGHT_INTENSITY = 0.015f;
+    public static final float NIGHT_INTENSITY = 0.035f;
     public static final float DUSK_INTENSITY = 0.075f;
     public static final float DAWN_INTENSITY = 0.095f;
     public static final float DAY_INTENSITY = 0.15f;
 
     private static final float FADE_EVERY = 500f; // 0.5 sec
 
+    private static final float FADE_DAWN_EVERY = 500f;
+
+    private static final float FADE_NIGHT_EVERY = 1500f; // 1.5sec
+
     private long lastIntensityFade;
 
-    public static final  Vector3 bright = new Vector3(6.3f, 6.3f, 6.7f);
+    public static final Vector3 bright = new Vector3(6.3f, 6.3f, 6.7f);
 
     public static final Vector3 dark = new Vector3(0.3f, 0.3f, 0.7f);
 
@@ -42,7 +46,7 @@ public class DayNightCycleComponent {
 
     private float intensity;
 
-    private DayNightCycleConfig config;
+    private final DayNightCycleConfig config;
 
     private DayNightCycleStatus currentPartOfDay;
 
@@ -51,19 +55,20 @@ public class DayNightCycleComponent {
      */
     public DayNightCycleComponent() {
 
-        Pixmap map = new Pixmap(128, 128, Pixmap.Format.RGBA8888);;
+        Pixmap map = new Pixmap(128, 128, Pixmap.Format.RGBA8888);
+        ;
         map.setColor(Color.BLACK);
         map.fillRectangle(0, 0, map.getWidth(), map.getHeight());
         BLACK_IMAGE.setTexture(new Texture(map));
 
         this.ambientColour = bright;
-        this.intensity = DAY_INTENSITY;
+        this.intensity = DAWN_INTENSITY;
 
         this.lastIntensityFade = System.currentTimeMillis();
 
         ShaderProgram.pedantic = false;
         var vertexShader = Gdx.files.internal("shaders/base.vert");
-        var lightShader=  Gdx.files.internal("shaders/light.frag");
+        var lightShader = Gdx.files.internal("shaders/light.frag");
         this.dayNightCycleShader = new ShaderProgram(vertexShader, lightShader);
 
         /* Subscribe to part of day changes */
@@ -75,16 +80,21 @@ public class DayNightCycleComponent {
         }
 
 
-        this.config =  FileLoader.readClass(DayNightCycleConfig.class, "configs/DayNight.json");
+        this.config = FileLoader.readClass(DayNightCycleConfig.class, "configs/DayNight.json");
     }
 
     /**
-     *  Called to apply the shader
-     *  Should be frequently called as ambientColor and intensity might changed.
+     * Called to apply the shader
+     * Should be frequently called as ambientColor and intensity might changed.
      *
      * @param batch the sprite batch to apply the filter to
      */
     public void render(SpriteBatch batch) {
+
+        /* Start dayNightCycle on first render, indicates all assets have loaded */
+        if (!ServiceLocator.getDayNightCycleService().hasStarted()) {
+            ServiceLocator.getDayNightCycleService().start();
+        }
 
         if (!ServiceLocator.getDayNightCycleService().hasEnded()) {
             this.fade();
@@ -104,25 +114,41 @@ public class DayNightCycleComponent {
     /**
      * Give steps values according to number of seconds in each part of day.
      * Used for gradually fading to the next part of day
-     * @param partOfDay the part of day
+     *
      * @return the amount to step up by
      */
-    public float getCycleIntensityStep(DayNightCycleStatus partOfDay) {
+    public float getCurrentCycleIntensityStep() {
         /* converts length to seconds */
-        return switch (partOfDay) {
-            case DAWN -> getIntensityDifference(partOfDay)/(config.dawnLength/FADE_EVERY);
-            case DAY -> getIntensityDifference(partOfDay)/(config.dayLength/FADE_EVERY);
-            case DUSK -> getIntensityDifference(partOfDay)/(config.duskLength/FADE_EVERY);
-            case NIGHT -> getIntensityDifference(partOfDay)/(config.nightLength/FADE_EVERY);
+        return switch (currentPartOfDay) {
+            case DAWN -> getIntensityDifference(currentPartOfDay) / (config.dawnLength / FADE_DAWN_EVERY);
+            case DAY -> getIntensityDifference(currentPartOfDay) / (config.dayLength / FADE_EVERY);
+            case DUSK -> getIntensityDifference(currentPartOfDay) / (config.duskLength / FADE_EVERY);
+            case NIGHT -> getIntensityDifference(currentPartOfDay) / (config.nightLength / FADE_NIGHT_EVERY);
             default -> 0.5f;
         };
     }
 
     /**
-     * Return the intensity between the part of day and next
+     * Gets the current part of day intensity
      *
-     * @param partOfDay
-     * @return
+     * @return the intensity for current part of day
+     */
+    public float getCurrentPartOfDayIntensity() {
+        return switch (currentPartOfDay) {
+            case DAWN -> DAWN_INTENSITY;
+            case DAY -> DAY_INTENSITY;
+            case DUSK -> DUSK_INTENSITY;
+            case NIGHT -> NIGHT_INTENSITY;
+            default -> 0.0f; // not going to happen
+        };
+    }
+
+    /**
+     * Computes the intensity between the part of day and next
+     *
+     * @param partOfDay the part of day to get next part of day difference from
+     *
+     * @return the intensity difference
      */
     public float getIntensityDifference(DayNightCycleStatus partOfDay) {
         return switch (partOfDay) {
@@ -135,7 +161,6 @@ public class DayNightCycleComponent {
     }
 
 
-
     /**
      * Invoked when the part of day has changed
      *
@@ -143,46 +168,78 @@ public class DayNightCycleComponent {
      */
     public void onPartOfDayChange(DayNightCycleStatus partOfDay) {
         this.currentPartOfDay = partOfDay;
+        this.intensity = getCurrentPartOfDayIntensity();
     }
 
     /**
-     * Gradually fades to the next part of the day
+     * Gradually fades to the next part of the day.
+     * Night overrides its own light fading and replaces light shader with dark one
      */
     private void fade() {
         if (currentPartOfDay != null) {
             if (shouldFade()) {
-                    this.intensity = switch (currentPartOfDay) {
-                        case DAWN, NIGHT -> intensity + getCycleIntensityStep(currentPartOfDay);
-                        case DAY, DUSK -> intensity - getCycleIntensityStep(currentPartOfDay);
-                        default -> intensity;
-                    };
+                this.intensity = switch (currentPartOfDay) {
+                    case DAWN, NIGHT -> intensity + getCurrentCycleIntensityStep();
+                    case DAY, DUSK -> intensity - getCurrentCycleIntensityStep();
+                    default -> intensity;
+                };
 
+                if (currentPartOfDay != DayNightCycleStatus.NIGHT) {
                     this.ambientColour = bright;
+                } else {
+                    // override for NIGHT
+                    this.intensity = 0.75f;
+                    this.ambientColour = dark;
+                }
 
-                    this.lastIntensityFade = System.currentTimeMillis();
-                }
-                }
+                this.lastIntensityFade = System.currentTimeMillis();
+            }
+        }
+
+
+    }
+
+    /**
+     * Gets the intensity to go to from the current part of day.
+     * Say if current day is DAWN then the target intensity is DAY
+     * and so on.
+     *
+     * @return The target intensity to reach
+     */
+    private float getCurrentPartOfDayTargetIntensity() {
+        return switch (currentPartOfDay) {
+            case DAWN -> DAY_INTENSITY;
+            case DAY -> DUSK_INTENSITY;
+            case DUSK -> NIGHT_INTENSITY;
+            case NIGHT -> DAWN_INTENSITY;
+            default -> 0.0f; // never gonna happen
+        };
     }
 
     /**
      * Signals whether we need to fade to next part of day.
      * It's based on the number of milliseconds set per fade step
+     * some parts of day fade faster and others slower.
+     * Add bounds so it doesn't get too bright or too dark
      *
      * @return true if fade is needed false otherwise
      */
     private boolean shouldFade() {
-        return System.currentTimeMillis() - lastIntensityFade >= FADE_EVERY;
-    }
+        if (currentPartOfDay == DayNightCycleStatus.DAWN && intensity <= getCurrentPartOfDayTargetIntensity()) {
+            return (System.currentTimeMillis() - lastIntensityFade) >= FADE_DAWN_EVERY;
+        } else if (currentPartOfDay == DayNightCycleStatus.NIGHT && intensity <= getCurrentPartOfDayTargetIntensity()) {
+            return (System.currentTimeMillis() - lastIntensityFade) >= FADE_NIGHT_EVERY;
+        } else if (currentPartOfDay == DayNightCycleStatus.DUSK && intensity >= getCurrentPartOfDayTargetIntensity()) {
+            return (System.currentTimeMillis() - lastIntensityFade) >= FADE_EVERY;
+        } else if (currentPartOfDay == DayNightCycleStatus.DAY && intensity >= getCurrentPartOfDayTargetIntensity()) {
+            return (System.currentTimeMillis() - lastIntensityFade) >= FADE_EVERY;
+        }
 
-    public ShaderProgram getDayNightCycleShader() {
-        return dayNightCycleShader;
+        return false;
     }
 
     public Vector3 getAmbientColour() {
         return ambientColour;
     }
 
-    public float getIntensity() {
-        return intensity;
-    }
 }

--- a/source/core/src/main/com/deco2800/game/screens/MainGameScreen.java
+++ b/source/core/src/main/com/deco2800/game/screens/MainGameScreen.java
@@ -131,7 +131,6 @@ public class MainGameScreen extends ScreenAdapter {
     renderer = RenderFactory.createRenderer();
     renderer.getCamera().getEntity().setPosition(CAMERA_POSITION);
     renderer.getDebug().renderPhysicsWorld(physicsEngine.getWorld());
-    ServiceLocator.getDayNightCycleService().start();
     loadAssets();
 
     logger.debug("Initialising main game screen entities");


### PR DESCRIPTION
- Swap to darker shader for night (previous darkness before Sprint 4)
- Fix bug where shader keeps getting brighter 
- Fix bug where shader does not stop at night
- Start DayNightCycleService on first render of DayNight